### PR TITLE
fix missing import

### DIFF
--- a/app/src/main/java/in/co/gorest/grblcontroller/GrblActivity.java
+++ b/app/src/main/java/in/co/gorest/grblcontroller/GrblActivity.java
@@ -25,6 +25,7 @@ import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;


### PR DESCRIPTION
Currently the master branch doesn't compile in Android Studio because of a missing import after #166 : DialogInterface is used in GrblActivity.java without being imported.